### PR TITLE
Fixed shebang and syntax meta declaration

### DIFF
--- a/gatk4-HaplotypeCaller.nf
+++ b/gatk4-HaplotypeCaller.nf
@@ -1,6 +1,4 @@
-#! /usr/bin/env nextflow
-
-//vim: syntax=groovy -*- mode: groovy;-*-
+#!/usr/bin/env nextflow
 
 // Copyright (C) 2018 IARC/WHO
 


### PR DESCRIPTION
Nextflow syntax is now properly recognised by GitHub