### PR TITLE
Picard dependency, GATK scatter different file extensions for interval lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Small pipeline to call recalibrated BAM, on a per sample basis, and store the gV
 
 1. This pipeline is based on [nextflow](https://www.nextflow.io). As we have several nextflow pipelines, we have centralized the common information in the [IARC-nf](https://github.com/IARCbioinfo/IARC-nf) repository. Please read it carefully as it contains essential information for the installation, basic usage and configuration of nextflow and our pipelines.
 2. [GATK4 executables](https://software.broadinstitute.org/gatk/download/)
+3. [Picard Tools](https://broadinstitute.github.io/picard/)
 
 ## Input
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Small pipeline to call recalibrated BAM, on a per sample basis, and store the gV
 - `--output_dir` : the folder that will contain your test_123.gVCF file or your test_001.gVCF, test_002.gVCF, ... files.
 - `--ref_fasta` : your reference in FASTA. Of course, be sure it is compatible (or the same) with the one that aligned your BAM file(s).
 - `--gatk_exec` : the full path to your GATK4 binary file.
+- `--picard_dir` : directory that contains `picard.jar`
 - `--interval_list` : a file for the intervals to call on. [More information on interval_list format](https://gatkforums.broadinstitute.org/gatk/discussion/1319/collected-faqs-about-interval-lists).
 
 A nextflow.config is also included, modify for suitability outside our pre-configured clusters ([see Nexflow configuration](https://www.nextflow.io/docs/latest/config.html#configuration-file)).


### PR DESCRIPTION
This pipeline broke for me for two reasons:

1. Picard tools was required, but the dependency wasn't listed in the README, 
2. My version of GATK 4 SplitIntervals creates files with the extension `.interval_list`, and no matter the interval format I used, it always output that extension.

These are the changes that I made to make it run with my versions. My NextFlow skills are not great, so there may be a better way to gather both `.interval_list` or `.intervals`, if that makes more sense.

I'm happy to make any changes to make this pull request better, as well.